### PR TITLE
Allow threshold to be configured at PointOctree instantiation

### DIFF
--- a/src/points/PointOctree.js
+++ b/src/points/PointOctree.js
@@ -4,15 +4,6 @@ import { PointOctant } from "./PointOctant.js";
 import { RayPointIntersection } from "./RayPointIntersection.js";
 
 /**
- * A threshold for distance comparisons.
- *
- * @type {Number}
- * @private
- */
-
-let THRESHOLD;
-
-/**
  * Recursively counts how many points are in the given octant.
  *
  * @private
@@ -235,7 +226,7 @@ function fetch(point, octree, octant) {
 
 			for(i = 0, l = points.length; result === null && i < l; ++i) {
 
-				if(point.distanceToSquared(points[i]) <= THRESHOLD) {
+				if(point.distanceToSquared(points[i]) <= octree.threshold) {
 
 					result = octant.data[i];
 
@@ -295,7 +286,7 @@ function move(point, position, octree, octant, parent, depth) {
 
 				for(i = 0, l = points.length; i < l; ++i) {
 
-					if(point.distanceToSquared(points[i]) <= THRESHOLD) {
+					if(point.distanceToSquared(points[i]) <= octree.threshold) {
 
 						// The point exists! Update its position.
 						points[i].copy(position);
@@ -492,7 +483,7 @@ export class PointOctree extends Octree {
 	 * @param {Number} [threshold=1E-6] - Threshold for equality in move and fetch
 	 */
 
-	constructor(min, max, bias = 0.0, maxPoints = 8, maxDepth = 8, threshold = 1E-6) {
+	constructor(min, max, bias = 0.0, maxPoints = 8, maxDepth = 8, threshold = 1e-6) {
 
 		super();
 
@@ -551,12 +542,12 @@ export class PointOctree extends Octree {
 
 		/**
 		 * The amount of distanceSquared between points for equality match in move and fetch.
-		 * Default: 1E-6
+		 * Default: 1e-6
 		 * 
 		 * @type {Number}
 		 */
 
-		THRESHOLD = threshold;
+		this.threshold = threshold;
 
 	}
 

--- a/src/points/PointOctree.js
+++ b/src/points/PointOctree.js
@@ -10,7 +10,7 @@ import { RayPointIntersection } from "./RayPointIntersection.js";
  * @private
  */
 
-var THRESHOLD;
+let THRESHOLD;
 
 /**
  * Recursively counts how many points are in the given octant.
@@ -492,7 +492,7 @@ export class PointOctree extends Octree {
 	 * @param {Number} [threshold=1E-6] - Threshold for equality in move and fetch
 	 */
 
-	constructor(min, max, bias = 0.0, maxPoints = 8, maxDepth = 8, threshold= 1E-6) {
+	constructor(min, max, bias = 0.0, maxPoints = 8, maxDepth = 8, threshold = 1E-6) {
 
 		super();
 

--- a/src/points/PointOctree.js
+++ b/src/points/PointOctree.js
@@ -10,7 +10,7 @@ import { RayPointIntersection } from "./RayPointIntersection.js";
  * @private
  */
 
-const THRESHOLD = 1e-6;
+var THRESHOLD;
 
 /**
  * Recursively counts how many points are in the given octant.
@@ -489,9 +489,10 @@ export class PointOctree extends Octree {
 	 * @param {Number} [bias=0.0] - An octant boundary bias.
 	 * @param {Number} [maxPoints=8] - Number of distinct points per octant before it splits up.
 	 * @param {Number} [maxDepth=8] - The maximum tree depth level, starting at 0.
+	 * @param {Number} [threshold=1E-6] - Threshold for equality in move and fetch
 	 */
 
-	constructor(min, max, bias = 0.0, maxPoints = 8, maxDepth = 8) {
+	constructor(min, max, bias = 0.0, maxPoints = 8, maxDepth = 8, threshold= 1E-6) {
 
 		super();
 
@@ -547,6 +548,15 @@ export class PointOctree extends Octree {
 		 */
 
 		this.pointCount = 0;
+
+		/**
+		 * The amount of distanceSquared between points for equality match in move and fetch.
+		 * Default: 1E-6
+		 * 
+		 * @type {Number}
+		 */
+
+		THRESHOLD = threshold;
 
 	}
 


### PR DESCRIPTION
Ran into some trouble with points very close to each other being nondeterministic as to which point I manipulated on a move.  Since I had the exact coordinates of the object to move I wanted to set threshold to 0 or at least even smaller than 1E-6.


